### PR TITLE
Use direct endpoint entries in default configuration

### DIFF
--- a/templates/cm-config.yaml
+++ b/templates/cm-config.yaml
@@ -19,26 +19,6 @@ data:
         "cache_ttl":  "{{ .service.cache_ttl }}",
         "output_encoding": "{{ .service.output_encoding }}",
         "extra_config": {{ marshal .service.extra_config }},
-        "endpoints": [
-            {{ range $idx, $endpoint := .endpoint.profile }}
-            {{if $idx}},{{end}}
-            {
-                "endpoint": "{{ $endpoint.endpoint }}",
-                "method": "{{ $endpoint.method }}",
-                "backend": [
-                    {
-                    "url_pattern": "{{ $endpoint.backend_url_pattern }}",
-                    "method": "{{ $endpoint.backend_method }}",
-                    "host": [
-                        "{{ $endpoint.backend_host }}"
-                    ],
-                    "extra_config": {
-                        {{ include "rate_limit_backend.tmpl" }}
-                    }
-                    }
-                ]
-            }
-            {{ end }}
-        ]
+        "endpoints": {{ include "endpoints.tmpl" }}
     }`}}
 {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -19,28 +19,36 @@ krakend:
         "max_rate": 0.5,
         "capacity": 1
       }
-  settings:
-    endpoint.json: |-
-      {
-          "profile": [
-              {
-                  "endpoint_prefix": "/test-1-api",
-                  "endpoint": "/test-1",
-                  "method": "GET",
-                  "backend_url_pattern": "/__debug/dbg",
-                  "backend_method": "GET",
-                  "backend_host": "http://localhost:8080"
-              },
-              {
-                  "endpoint_prefix": "/test-2-api",
-                  "endpoint": "/test-2",
-                  "method": "GET",
-                  "backend_url_pattern": "/__debug/dbg",
-                  "backend_method": "GET",
-                  "backend_host": "http://localhost:8080"
-              }
+    endpoints.tmpl: |-
+      [
+        {
+          "endpoint": "/test-1",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/__debug/dbg",
+              "method": "GET",
+              "host": [
+                "http://localhost:8080"
+              ]
+            }
           ]
-      }
+        },
+        {
+          "endpoint": "/test-2",
+          "method": "GET",
+          "backend": [
+            {
+              "url_pattern": "/__debug/dbg",
+              "method": "GET",
+              "host": [
+                "http://localhost:8080"
+              ]
+            }
+          ]
+        }
+      ]
+  settings:
     service.json: |-
       {
       	"port": 8080,


### PR DESCRIPTION
As done in the examples in the documentation, we originally had an
opinionated template for the endpoints which would only allow for
setting one endpoint to one backend. While this was nice for testing,
this is not ideal if we want to allow folks to have more control over
their endpoints.

So, we now are switching to allowing a raw endpoint configuration
insertion via Krakend's flexible configuration partials [1]. While
service authors will need be more acquainted with lura configuration,
specifically the endpoint constructs [2], it allows us to iterate faster
on verifying the krakend gateway and getting that deployed.

[1] https://www.krakend.io/docs/configuration/flexible-config/
[2] https://www.krakend.io/docs/endpoints/

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
