### PR TITLE
Add initial setting for liveness probe

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -49,10 +49,10 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
-          # livenessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          livenessProbe:
+            httpGet:
+              path: /__health
+              port: http
           # readinessProbe:
           #   httpGet:
           #     path: /


### PR DESCRIPTION
This uses krakend's default health check [1] to set up a k8s
`livenessProbe`. It's currently using default values which we might
adjust as needed once we run and analyze the gateway in an environment.

[1] https://www.krakend.io/docs/service-settings/health/

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
