### PR TITLE
Add configuration for injecting plugins by default

### DIFF
--- a/templates/cm-config.yaml
+++ b/templates/cm-config.yaml
@@ -18,6 +18,10 @@ data:
         "timeout": "{{ .service.timeout }}",
         "cache_ttl":  "{{ .service.cache_ttl }}",
         "output_encoding": "{{ .service.output_encoding }}",
+        "plugin": {
+            "pattern":".so",
+            "folder": "/usr/lib/krakend/plugins/"
+        },
         "extra_config": {{ marshal .service.extra_config }},
         "endpoints": [
             {{ range $idx, $endpoint := .endpoint.profile }}


### PR DESCRIPTION
The [Portón](https://github.com/infratographer/porton) project injects
plugins through a specific path (`/usr/lib/krakend/plugins/`) by
default. This takes that assumption into use by default and enables the
needed configuration.

Note that this will stay this way while we get this working. In the
future, we might make this optional if others want to take this helm
chart into use.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
