### PR TITLE
Enable importing endpoint configuration from a container image

### DIFF
--- a/templates/cm-partials.yaml
+++ b/templates/cm-partials.yaml
@@ -7,3 +7,7 @@ data:
   {{ $key }}: |-
     {{ $value | nindent 4 }}
   {{- end }}
+  {{- if not .Values.krakend.endpoints.fromImage }}
+  endpoints.tmpl: |-
+    {{ .Values.krakend.endpoints.endpointsConfig | nindent 4 }}
+  {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -29,6 +29,33 @@ spec:
       serviceAccountName: {{ include "krakend.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      initContainers:
+        - name: partials-copier
+          image: "{{ .Values.krakend.partialsCopierImage.registry }}/{{ .Values.krakend.partialsCopierImage.repository }}:{{ .Values.krakend.partialsCopierImage.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.krakend.partialsCopierImage.pullPolicy }}
+          command:
+            - /bin/sh
+          args:
+            - "-c"
+            - "cp"
+            - "-r"
+            - "/partials/*"
+            - "/partialsButReally/"
+          volumeMounts:
+            - name: partialsButReally
+              mountPath: /partialsButReally
+            - name: partials
+              mountPath: /partials
+      {{- if .Values.krakend.endpoints.fromImage }}
+        - name: endpoints-copier
+          image: "{{ required "krakend.endpoints.image.registry is required" .Values.krakend.endpoints.image.registry }}/{{ required "krakend.endpoints.image.repository is required" .Values.krakend.endpoints.image.repository }}:{{ required "krakend.endpoints.image.tag is required" .Values.krakend.endpoints.image.tag }}"
+          imagePullPolicy: {{ .Values.krakend.endpoints.image.pullPolicy }}
+          command: {{ .Values.krakend.endpoints.image.command }}
+          args: {{ .Values.krakend.endpoints.image.args }}
+          volumeMounts:
+            - name: partialsButReally
+              mountPath: /endpoints
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
@@ -60,7 +87,7 @@ spec:
           volumeMounts:
             - name: config
               mountPath: /etc/krakend
-            - name: partials
+            - name: partialsButReally
               mountPath: /etc/krakend/partials
             - name: settings
               mountPath: /etc/krakend/settings
@@ -93,3 +120,5 @@ spec:
         - name: templates
           configMap:
             name: {{ include "krakend.fullname" . }}-templates
+        - name: partialsButReally
+          emptyDir: {}

--- a/values.yaml
+++ b/values.yaml
@@ -8,6 +8,11 @@ image:
 
 krakend:
   config: ""
+  partialsCopierImage:
+    registry: docker.io
+    repository: library/alpine
+    tag: "3.17.1"
+    pullPolicy: IfNotPresent
   partials:
     input_headers.tmpl: |-
       "input_headers": [
@@ -19,7 +24,38 @@ krakend:
         "max_rate": 0.5,
         "capacity": 1
       }
-    endpoints.tmpl: |-
+  settings:
+    service.json: |-
+      {
+      	"port": 8080,
+      	"environment": "PRODUCTION",
+      	"default_host": "http://localhost:8080",
+      	"timeout": "3s",
+      	"cache_ttl": "3s",
+      	"output_encoding": "json",
+      	"extra_config": {}
+      }
+  templates: {}
+  endpoints:
+    # fromImage is a flag to indicate that the endpoints should be loaded from the image
+    # instead of the configmap. This happens as an initContainer.
+    fromImage: false
+    # image is the image to use to load the endpoints from
+    # Note that the registry, repository and tag must be set.
+    image:
+      registry:
+      repository:
+      tag:
+      pullPolicy: IfNotPresent
+      command: [ "/bin/sh" ]
+      args:
+        - "-c"
+        - cp
+        - /endpoints.json
+        - /endpoints/endpoints.tmpl
+    # If `fromImage` is set to false, the endpoints will be loaded from the
+    # partials configmap with this configuration
+    endpointsConfig: |-
       [
         {
           "endpoint": "/test-1",
@@ -48,18 +84,6 @@ krakend:
           ]
         }
       ]
-  settings:
-    service.json: |-
-      {
-      	"port": 8080,
-      	"environment": "PRODUCTION",
-      	"default_host": "http://localhost:8080",
-      	"timeout": "3s",
-      	"cache_ttl": "3s",
-      	"output_encoding": "json",
-      	"extra_config": {}
-      }
-  templates: {}
 
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Krakend.io endpoints may take most of the configuration and can get
quite big. Big enough that the ConfigMap's 1.5Mb of storage is not
enough. To address this limitation, we now allow for users to specify if
they want to import endpoints from a container image. This can be
enabled via the `krakend.endpoints.fromImage` value. However, since we
don't know what image they'll use, they need to specify this too.

So, a minimal values file that enables this configuration would look as
follows:

```yaml
krakend:
  krakend:
    endpoints:
        fromImage: true
        image:
          registry: "foo"
          repository: "bar"
          tag: "baz"
```

The idea is that folks will be able to generate images that will be
copied into the main API Gateway container's partials configuration.

Note that it's also possible to override the command to run in order to
copy these files, however, take into account that the resulting
"endpoints" configuration **must** have the name `endpoints.tmpl`.

The default command expects the container to have a file called
`endpoints.json`.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
