### PR TITLE
Switch default image to use krakend upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
 # Krakend
 
 This is a helm chart that deploys a [Krakend](https://www.krakend.io/) instance.
-It is heavily based on the assumptions made by the [infratographer](http://infratographer.com/)
-project.

--- a/values.yaml
+++ b/values.yaml
@@ -1,10 +1,10 @@
 replicaCount: 1
 
 image:
-  registry: ghcr.io
-  repository: infratographer/porton/porton
+  registry: docker.io
+  repository: devopsfaith/krakend
   pullPolicy: IfNotPresent
-  tag: "latest"
+  tag: "2.1.4"
 
 krakend:
   config: ""


### PR DESCRIPTION
We were initially assuming that this would be very targetted towards
Portón; however, so far it all seems general enough that we could
develop and promote a more general purpose helm chart.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
