### PR TITLE
Add ability to insert extra volumes (useful for setting up license)

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,6 +18,8 @@ jobs:
             testdir: 'default-data'
           - name: 'Scenario: with endpoints image'
             testdir: 'with-endpoints-image'
+          - name: 'Scenario: with extra mounts'
+            testdir: 'with-extra-mounts'
     env:
       KRAKEND_NS: krakend-test
     steps:
@@ -49,6 +51,14 @@ jobs:
         if: matrix.config.testdir == 'with-endpoints-image'
         run: |
           kind load docker-image --name chart-testing krakend-test:latest
+
+      # We copy our license file (which is just the apache license) into a secret with a sole key named LICENSE.
+      # This will be bind mounted into the krakend container as /etc/krakend/LICENSE.
+      # We're not testing the functionality of loading an actual krakend license here, just that the extra mount works.
+      - name: 'Create license secret'
+        run: |
+          kubectl create secret generic krakend-license --from-file=LICENSE=LICENSE --namespace $KRAKEND_NS
+        if: matrix.config.testdir == 'with-extra-mounts'
       
       - name: Install chart
         run: |

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | The affinity to use for the krakend pod |
+| extraVolumeMounts | array | `[]` | extraVolumeMounts allows you to mount extra volumes to the krakend pod |
+| extraVolumes | array | `[]` | extraVolumes allows you to mount extra volumes to the krakend pod |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use |
 | image.registry | string | `"docker.io"` | The image registry to use |
@@ -42,7 +44,7 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | krakend.endpoints.image.registry | string | `nil` | The image registry to use for the endpoints loader |
 | krakend.endpoints.image.repository | string | `nil` | The image repository to use for the endpoints loader Note that the image must contain a file named endpoints.json at the root of the image. |
 | krakend.endpoints.image.tag | string | `nil` | The image tag to use for the endpoints loader |
-| krakend.env | array | `[{"name":"FC_ENABLE","value":"1"},{"name":"FC_SETTINGS","value":"/etc/krakend/settings"},{"name":"FC_PARTIALS","value":"/etc/krakend/partials"},{"name":"FC_TEMPLATES","value":"/etc/krakend/templates"}]` | The environment variables to use for the krakend container. The default is just the ones needed to enable flexible configuration. |
+| krakend.env | array | `[{"name":"FC_ENABLE","value":"1"},{"name":"FC_SETTINGS","value":"/etc/krakend-src/settings"},{"name":"FC_PARTIALS","value":"/etc/krakend-src/partials"},{"name":"FC_TEMPLATES","value":"/etc/krakend-src/templates"}]` | The environment variables to use for the krakend container. The default is just the ones needed to enable flexible configuration. |
 | krakend.partials | Object | `{"input_headers.tmpl":"\"input_headers\": [\n  \"Content-Type\",\n  \"ClientId\"\n]","rate_limit_backend.tmpl":"\"qos/ratelimit/proxy\": {\n  \"max_rate\": 0.5,\n  \"capacity\": 1\n}"}` | The default configuration has a partials files that will be used to load several aspects of the configuration. If you want to include expra partials, add or remove them here. |
 | krakend.partialsCopierImage | object | `{"pullPolicy":"IfNotPresent","registry":"docker.io","repository":"library/alpine","tag":"3.17.1"}` | The default configuration has a partials file that will be used to load several aspects of the configuration. This is done through an initContainer that copies the partials to the /etc/krakend/partials folder. |
 | krakend.partialsCopierImage.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use for the partials copier |
@@ -81,3 +83,29 @@ Ensure that the documentation is up to date before pushing a pull request:
 ```bash
 helm-docs
 ```
+
+# Using Krakend.io Enterprise
+
+Krakend.io Enterprise is a commercial product that extends the capabilities
+of the open source Krakend.io API Gateway. It is available as a Docker image
+that can be used as a drop-in replacement for the open source image.
+
+In order to configure the helm chart to use it, you'd need a values file similar
+as the following:
+
+```yaml
+image:
+  registry: docker.io
+  repository: krakend/krakend-ee
+  tag: "2.1.2"
+extraVolumeMounts:
+  - name: license
+    mountPath: /etc/krakend/LICENSE
+    readOnly: true
+extraVolumes:
+  - name: license
+    secret:
+      secretName: krakend-license
+```
+
+Note the mount of the license file in the `/etc/krakend/LICENSE` path.

--- a/README.md.gotmpl
+++ b/README.md.gotmpl
@@ -31,3 +31,29 @@ Ensure that the documentation is up to date before pushing a pull request:
 ```bash
 helm-docs
 ```
+
+# Using Krakend.io Enterprise
+
+Krakend.io Enterprise is a commercial product that extends the capabilities
+of the open source Krakend.io API Gateway. It is available as a Docker image
+that can be used as a drop-in replacement for the open source image.
+
+In order to configure the helm chart to use it, you'd need a values file similar
+as the following:
+
+```yaml
+image:
+  registry: docker.io
+  repository: krakend/krakend-ee
+  tag: "2.1.2"
+extraVolumeMounts:
+  - name: license
+    mountPath: /etc/krakend/LICENSE
+    readOnly: true
+extraVolumes:
+  - name: license
+    secret:
+      secretName: krakend-license
+```
+
+Note the mount of the license file in the `/etc/krakend/LICENSE` path.

--- a/templates/_helpers.tpl
+++ b/templates/_helpers.tpl
@@ -62,8 +62,51 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Get krakend files directory
+*/}}
+{{- define "krakend.FilesDir" -}}
+{{- printf "/etc/krakend-src" -}}
+{{- end }}
+
+
+{{/*
+Get krakend config file directory
+*/}}
+{{- define "krakend.configFileDir" -}}
+{{- printf "%s/config" (include "krakend.FilesDir" .) -}}
+{{- end }}
+
+{{/*
 Get krakend config file name
 */}}
 {{- define "krakend.configFileName" -}}
-{{- printf "%s.tmpl" (include "krakend.fullname" .) }}
+{{- printf "%s.tmpl" (include "krakend.fullname" .) -}}
+{{- end }}
+
+{{/*
+Get krakend config file path
+*/}}
+{{- define "krakend.configFilePath" -}}
+{{- printf "%s/%s" (include "krakend.configFileDir" .) (include "krakend.configFileName" .) -}}
+{{- end }}
+
+{{/*
+Get krakend settings directory path
+*/}}
+{{- define "krakend.settingsDir" -}}
+{{- printf "%s/settings" (include "krakend.FilesDir" .) -}}
+{{- end }}
+
+{{/*
+Get krakend partials directory path
+*/}}
+{{- define "krakend.partialsDir" -}}
+{{- printf "%s/partials" (include "krakend.FilesDir" .) -}}
+{{- end }}
+
+{{/*
+Get krakend templates directory path
+*/}}
+{{- define "krakend.templatesDir" -}}
+{{- printf "%s/templates" (include "krakend.FilesDir" .) -}}
 {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -37,7 +37,7 @@ spec:
             - /bin/sh
           args:
             - "-c"
-            - "cp -r /partials/* /partials-but-really/"
+            - "cp /partials/* /partials-but-really/"
           volumeMounts:
             - name: partials-but-really
               mountPath: /partials-but-really
@@ -66,7 +66,7 @@ spec:
           args:
             - "run"
             - "-c"
-            - "/etc/krakend/{{ include "krakend.configFileName" . }}"
+            - "{{ include "krakend.configFilePath" . }}"
             - "-p"
             - {{ quote .Values.service.targetPort }}
           env:
@@ -89,13 +89,16 @@ spec:
           #     port: http
           volumeMounts:
             - name: config
-              mountPath: /etc/krakend
+              mountPath: {{ include "krakend.configFileDir" . }}
             - name: partials-but-really
-              mountPath: /etc/krakend/partials
+              mountPath: {{ include "krakend.partialsDir" . }}
             - name: settings
-              mountPath: /etc/krakend/settings
+              mountPath: {{ include "krakend.settingsDir" . }}
             - name: templates
-              mountPath: /etc/krakend/templates
+              mountPath: {{ include "krakend.templatesDir" . }}
+            {{- with .Values.extraVolumeMounts }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
       {{- with .Values.nodeSelector }}
@@ -125,3 +128,6 @@ spec:
             name: {{ include "krakend.fullname" . }}-templates
         - name: partials-but-really
           emptyDir: {}
+        {{- with .Values.extraVolumes }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}

--- a/tests/with-extra-mounts/values.yaml
+++ b/tests/with-extra-mounts/values.yaml
@@ -1,0 +1,8 @@
+extraVolumeMounts:
+  - name: license
+    mountPath: /etc/krakend
+    readOnly: true
+extraVolumes:
+  - name: license
+    secret:
+      secretName: krakend-license

--- a/values.yaml
+++ b/values.yaml
@@ -18,11 +18,11 @@ krakend:
     - name: FC_ENABLE
       value: '1'
     - name: FC_SETTINGS
-      value: '/etc/krakend/settings'
+      value: '/etc/krakend-src/settings'
     - name: FC_PARTIALS
-      value: '/etc/krakend/partials'
+      value: '/etc/krakend-src/partials'
     - name: FC_TEMPLATES
-      value: '/etc/krakend/templates'
+      value: '/etc/krakend-src/templates'
   # -- (string, optional) If set, this key will contain the full configuration of the krakend service
   config: ""
   # -- The default configuration has a partials file that
@@ -201,3 +201,9 @@ tolerations: []
 
 # -- (object) The affinity to use for the krakend pod
 affinity: {}
+
+# -- (array) extraVolumeMounts allows you to mount extra volumes to the krakend pod
+extraVolumeMounts: []
+
+# -- (array) extraVolumes allows you to mount extra volumes to the krakend pod
+extraVolumes: []


### PR DESCRIPTION
In cases where folks want to deploy krakend enterprise, they'd need to
have the LICENSE file in a specific location. With the current
configuratoin it's not trivial... So, this changes the configuration
mount to instead exist in a sub-directory as opposed to using
`/etc/krakend` directly.

On the other hand, this also added the generic keys `extraVolumeMounts`
and `extraVolumes` which allow us to inject the needed license file. An
example of using this would look as follows:

```yaml
extraVolumeMounts:
  - name: license
    mountPath: /etc/krakend/LICENSE
    readOnly: true
extraVolumes:
  - name: license
    secret:
      secretName: krakend-license
```

This also now changes the base directory for the krakend configs to be `/etc/krakend-src`, since that allows us to not have conflicting bind-mounts with the license file.