### PR TITLE
Simplify Release version updates

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,9 +3,8 @@ release: ## Issues a release
 	@test -n "$(TAG)" || (echo "The TAG variable must be set" && exit 1)
 	@echo "Releasing v$(TAG)"
 	git checkout -b "release-$(TAG)"
-	sed -i "s%[Version: .*]%[Version: $(TAG)]%" README.md
-	sed -i "s%/Version-.*-]%/Version-$(TAG)-%" README.md
 	sed -i "s%version: .*%version: $(TAG)%" Chart.yaml
+	helm-docs
 	git add README.md
 	git add Chart.yaml
 	git commit -m "Release v$(TAG)"


### PR DESCRIPTION
We were modifying the README directly while we could have just called
`helm-docs`. This simplifies and solves some bugs in the docs
generation for releases.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
