### PR TITLE
Automatically create a GitHub release when a tag is detected

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,3 +22,18 @@ jobs:
           charts_url: 'https://helm.equinixmetal.com'
           repository: 'charts'
           branch: gh-pages
+
+  gh-release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Release
+        uses: softprops/action-gh-release@v1
+        with:
+          generate_release_notes: true
+


### PR DESCRIPTION
This will create a nice little relesae in GitHub with automatic release
notes.

TODO: Ensure the release points to the generated tarball.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
