### PR TITLE
Add ability to set up custom service annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources | object | `{}` | The resources to use for the krakend pod |
 | securityContext | object | `{}` | The securityContext to use for the krakend container |
-| service | object | `{"port":80,"targetPort":8080,"type":"ClusterIP"}` | The service settings to use for the krakend service |
+| service | object | `{"annotations":{},"port":80,"targetPort":8080,"type":"ClusterIP"}` | The service settings to use for the krakend service |
+| service.annotations | object | `{}` | The annotations to use for the service |
 | service.port | int | `80` | The port to use for the service |
 | service.targetPort | int | `8080` | The target port to use for the service |
 | service.type | string | `"ClusterIP"` | The type of service to use |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "krakend.fullname" . }}
   labels:
     {{- include "krakend.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/values.yaml
+++ b/values.yaml
@@ -168,6 +168,8 @@ service:
   port: 80
   # -- (int) The target port to use for the service
   targetPort: 8080
+  # -- (object) The annotations to use for the service
+  annotations: {}
 
 # -- (object) The ingress settings to use for the krakend ingress
 ingress:


### PR DESCRIPTION
This is useful when using utilities like MetalLB that work via
annotations.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
