### PR TITLE
Allow for using templated service annotations

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -20,6 +20,8 @@ jobs:
             testdir: 'with-endpoints-image'
           - name: 'Scenario: with extra mounts'
             testdir: 'with-extra-mounts'
+          - name: 'Scenario: with templated annotations'
+            testdir: 'with-templated-annotations'
     env:
       KRAKEND_NS: krakend-test
     steps:

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -4,9 +4,11 @@ metadata:
   name: {{ include "krakend.fullname" . }}
   labels:
     {{- include "krakend.labels" . | nindent 4 }}
-  {{- with .Values.service.annotations }}
+  {{- if .Values.service.annotations }}
   annotations:
-    {{- toYaml . | nindent 4 }}
+    {{- range $key, $value := .Values.service.annotations }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
   {{- end }}
 spec:
   type: {{ .Values.service.type }}

--- a/tests/with-templated-annotations/values.yaml
+++ b/tests/with-templated-annotations/values.yaml
@@ -1,0 +1,7 @@
+---
+clusterInfo:
+  fqdn: "test-cluster.example.com"
+
+service:
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: krakend-0.{{ .Values.clusterInfo.fqdn }}


### PR DESCRIPTION
This is useful for cluster-specific settings that require extra logic.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
