### PR TITLE
Add secure defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | podSecurityContext | object | `{}` | The securityContext to use for the krakend pod |
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources | object | `{}` | The resources to use for the krakend pod |
-| securityContext | object | `{}` | The securityContext to use for the krakend container |
+| securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | The securityContext to use for the krakend container |
 | service | object | `{"annotations":{},"port":80,"targetPort":8080,"type":"ClusterIP"}` | The service settings to use for the krakend service |
 | service.annotations | object | `{}` | The annotations to use for the service |
 | service.port | int | `80` | The port to use for the service |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -33,6 +33,15 @@ spec:
         - name: partials-copier
           image: "{{ .Values.krakend.partialsCopierImage.registry }}/{{ .Values.krakend.partialsCopierImage.repository }}:{{ .Values.krakend.partialsCopierImage.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.krakend.partialsCopierImage.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
           command:
             - /bin/sh
           args:
@@ -47,6 +56,15 @@ spec:
         - name: endpoints-copier
           image: "{{ .Values.krakend.endpoints.image.registry }}{{ if .Values.krakend.endpoints.image.registry }}/{{ end }}{{ required "krakend.endpoints.image.repository is required" .Values.krakend.endpoints.image.repository }}:{{ required "krakend.endpoints.image.tag is required" .Values.krakend.endpoints.image.tag }}"
           imagePullPolicy: {{ .Values.krakend.endpoints.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+            capabilities:
+              drop:
+                - ALL
           command: {{ .Values.krakend.endpoints.image.command }}
           {{- with .Values.krakend.endpoints.image.args }}
           args:
@@ -88,6 +106,8 @@ spec:
           #     path: /
           #     port: http
           volumeMounts:
+            - name: tmp
+              mountPath: /tmp
             - name: config
               mountPath: {{ include "krakend.configFileDir" . }}
             - name: partials-but-really
@@ -114,6 +134,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       volumes:
+        - name: tmp
+          emptyDir: {}
         - name: config
           configMap:
             name: {{ include "krakend.fullname" . }}-config

--- a/values.yaml
+++ b/values.yaml
@@ -159,13 +159,16 @@ podSecurityContext: {}
   # fsGroup: 2000
 
 # -- (object) The securityContext to use for the krakend container
-securityContext: {}
-  # capabilities:
-  #   drop:
-  #   - ALL
-  # readOnlyRootFilesystem: true
-  # runAsNonRoot: true
-  # runAsUser: 1000
+securityContext:
+  allowPrivilegeEscalation: false
+  runAsNonRoot: true
+  runAsUser: 1000
+  readOnlyRootFilesystem: true
+  capabilities:
+    drop:
+      - ALL
+    add:
+      - NET_BIND_SERVICE
 
 # -- (object) The service settings to use for the krakend service
 service:


### PR DESCRIPTION
This adds secure defaults for the containers' securityContext
configuration.

Note that the user `1000` was chosen because it's the default that the krakend upstream container provisions.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
