### PR TITLE
Skip health endpoint from access logs in default configuration

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -71,7 +71,14 @@ krakend:
       	"timeout": "3s",
       	"cache_ttl": "3s",
       	"output_encoding": "json",
-      	"extra_config": {}
+      	"extra_config": {
+          "router": {
+            "@comment": "The health endpoint checks do not show in the logs",
+            "logger_skip_paths": [
+              "/__health"
+            ]
+          }
+        }
       }
   # -- While default configuration does not take into use
   # templates; you may want to add your own templates here.


### PR DESCRIPTION
This makes sure that access to the health endpoint doesn't show up in
the logs by default. Folks can still modify this by having a custom
service configuration set up.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
