### PR TITLE
Skip health endpoint from access logs in default configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | krakend.partialsCopierImage.repository | string | `"library/alpine"` | The image repository to use for the partials copier |
 | krakend.partialsCopierImage.resources | object | `{"limits":{"cpu":"100m","memory":"128Mi"},"requests":{"cpu":"100m","memory":"128Mi"}}` | The resources to use for the partials copier |
 | krakend.partialsCopierImage.tag | string | `"3.17.1"` | The image tag to use for the partials copier |
-| krakend.settings | object | `{"service.json":"{\n\t\"port\": 8080,\n\t\"environment\": \"PRODUCTION\",\n\t\"default_host\": \"http://localhost:8080\",\n\t\"timeout\": \"3s\",\n\t\"cache_ttl\": \"3s\",\n\t\"output_encoding\": \"json\",\n\t\"extra_config\": {}\n}"}` | The default configuration has a settings files that will be used to load several aspects of the configuration. |
+| krakend.settings | object | `{"service.json":"{\n\t\"port\": 8080,\n\t\"environment\": \"PRODUCTION\",\n\t\"default_host\": \"http://localhost:8080\",\n\t\"timeout\": \"3s\",\n\t\"cache_ttl\": \"3s\",\n\t\"output_encoding\": \"json\",\n\t\"extra_config\": {\n    \"router\": {\n      \"@comment\": \"The health endpoint checks do not show in the logs\",\n      \"logger_skip_paths\": [\n        \"/__health\"\n      ]\n    }\n  }\n}"}` | The default configuration has a settings files that will be used to load several aspects of the configuration. |
 | krakend.templates | object | `{}` | While default configuration does not take into use templates; you may want to add your own templates here. Note that you'd need to set a custom configuration file to use them. |
 | nameOverride | string | `""` |  |
 | nodeSelector | object | `{}` | The nodeSelector to use for the krakend pod |

--- a/values.yaml
+++ b/values.yaml
@@ -71,7 +71,14 @@ krakend:
       	"timeout": "3s",
       	"cache_ttl": "3s",
       	"output_encoding": "json",
-      	"extra_config": {}
+      	"extra_config": {
+          "router": {
+            "@comment": "The health endpoint checks do not show in the logs",
+            "logger_skip_paths": [
+              "/__health"
+            ]
+          }
+        }
       }
   # -- While default configuration does not take into use
   # templates; you may want to add your own templates here.


### PR DESCRIPTION
This makes sure that access to the health endpoint doesn't show up in the logs by default. Folks can still modify this by having a custom service configuration set up.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>