### PR TITLE
Use health endpoint for readiness probe

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -105,10 +105,10 @@ spec:
             httpGet:
               path: /__health
               port: http
-          # readinessProbe:
-          #   httpGet:
-          #     path: /
-          #     port: http
+          readinessProbe:
+            httpGet:
+              path: /__health
+              port: http
           volumeMounts:
             - name: tmp
               mountPath: /tmp


### PR DESCRIPTION
This uses the health endpoint for the readiness probe.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
