### PR TITLE
Add support for Argo Rollouts as a deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | The affinity to use for the krakend pod |
+| deploymentType | string | `"deployment"` | The deployment type to use for the krakend service Valid values are `deployment` and `rollout` |
 | extraVolumeMounts | array | `[]` | extraVolumeMounts allows you to mount extra volumes to the krakend pod |
 | extraVolumes | array | `[]` | extraVolumes allows you to mount extra volumes to the krakend pod |
 | fullnameOverride | string | `""` |  |
@@ -62,6 +63,7 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | podSecurityContext | object | `{}` | The securityContext to use for the krakend pod |
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources | object | `{}` | The resources to use for the krakend pod |
+| rolloutStrategy | object | `{"canary":{"maxSurge":"25%","maxUnavailable":0,"steps":[{"setWeight":10},{"pause":{"duration":"1m"}},{"setWeight":30},{"pause":{"duration":"1m"}},{"setWeight":50},{"pause":{"duration":"1m"}}]}}` | The Argo Rollouts strategy to use for the krakend service For more information, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/ Note that the `deploymentType` must be set to `rollout` for this to take effect. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | The securityContext to use for the krakend container |
 | service | object | `{"annotations":{},"port":80,"targetPort":8080,"type":"ClusterIP"}` | The service settings to use for the krakend service |
 | service.annotations | object | `{}` | The annotations to use for the service |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,5 +1,13 @@
+{{- if and (not (eq .Values.deploymentType "deployment")) (not (eq .Values.deploymentType "rollout")) }}
+{{- fail "Invalid deploymentType. Valid values are: deployment, rollout" }}
+{{- end }}
+{{- if eq .Values.deploymentType "deployment" }}
 apiVersion: apps/v1
 kind: Deployment
+{{- else if eq .Values.deploymentType "rollout" }}
+apiVersion: argoproj.io/v1alpha1
+kind: Rollout
+{{- end }}
 metadata:
   name: {{ include "krakend.fullname" . }}
   labels:
@@ -9,6 +17,12 @@ spec:
   selector:
     matchLabels:
       {{- include "krakend.selectorLabels" . | nindent 6 }}
+  {{- if eq .Values.deploymentType "rollout" }}
+  {{- with .Values.rolloutStrategy }}
+  strategy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  {{- end }}
   template:
     metadata:
       annotations:

--- a/values.yaml
+++ b/values.yaml
@@ -11,6 +11,28 @@ image:
   # -- The image pull policy to use
   pullPolicy: IfNotPresent
 
+# -- (string) The deployment type to use for the krakend service
+# Valid values are `deployment` and `rollout`
+deploymentType: deployment
+
+# -- (object) The Argo Rollouts strategy to use for the krakend service
+# For more information, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/
+# Note that the `deploymentType` must be set to `rollout` for this to take effect.
+rolloutStrategy:
+  canary:
+    maxSurge: "25%"
+    maxUnavailable: 0
+    steps:
+    - setWeight: 10
+    - pause:
+        duration: 1m
+    - setWeight: 30
+    - pause:
+        duration: 1m
+    - setWeight: 50
+    - pause:
+        duration: 1m
+
 krakend:
   # -- (array) The environment variables to use for the krakend container.
   # The default is just the ones needed to enable flexible configuration.


### PR DESCRIPTION
Argo Rollouts is a project that allows us to replace Kubernetes
Deployments and handle more complex deployment strategies [1]. It
currently supports canary and blue green deployments, with the added
value of providing a way of doing analysis on how a rollout is going
based on metrics (e.g. prometheus).

Testing this out, it seems like quite an ideal way of managing the
krakend API Gateway as it would greatly reduce the risk of rolling out
changes if we set up the rollout strategy and analysis templates
appropriately.

Testing this out locally, it seems like quite a versatile tool. However,
I wanted to get some more feedback first.

One caveat I see is that the Kuberentes CRD's are v1alpha1, which is not
ideal.

[1] https://argo-rollouts.readthedocs.io/en/stable/

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
