### PR TITLE
Add relevant JSON schema and lint job

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -92,3 +92,32 @@ jobs:
         run: |
           curl -s http://localhost:8081/directories/1 | jq -e '.version == "flavorless"'
         if: matrix.config.testdir == 'with-all-in-one-image'
+
+  helm-lint:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        config:
+          - name: 'Scenario: with default options'
+            testdir: 'default-data'
+          - name: 'Scenario: with all-in-one image'
+            testdir: 'with-all-in-one-image'
+          - name: 'Scenario: with extra mounts'
+            testdir: 'with-extra-mounts'
+          - name: 'Scenario: with templated annotations'
+            testdir: 'with-templated-annotations'
+    env:
+      KRAKEND_NS: krakend-test
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: 'Install helm'
+        uses: azure/setup-helm@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: lint
+        run: |
+          helm lint --values tests/${{ matrix.config.testdir }}/values.yaml .

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -1,9 +1,10 @@
 apiVersion: v2
 name: krakend
-description: A Helm chart for Kubernetes
+icon: https://www.krakend.io/images/logo-krakend.svg
+description: |-
+  A Helm chart for deploying krakend.io in Kubernetes provided
+  and maintained by your friends at Equinix Metal
 
 type: application
-
 version: 0.1.6
-
 appVersion: "0.1.0"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ This is a helm chart that deploys a [Krakend](https://www.krakend.io/) instance.
 
 ## Description
 
-A Helm chart for Kubernetes
+A Helm chart for deploying krakend.io in Kubernetes provided
+and maintained by your friends at Equinix Metal
 
 ## Usage
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -1,6 +1,3 @@
-{{- if and (not (eq .Values.deploymentType "deployment")) (not (eq .Values.deploymentType "rollout")) }}
-{{- fail "Invalid deploymentType. Valid values are: deployment, rollout" }}
-{{- end }}
 {{- if eq .Values.deploymentType "deployment" }}
 apiVersion: apps/v1
 kind: Deployment

--- a/values.schema.json
+++ b/values.schema.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "http://json-schema.org/schema#",
+    "type": "object",
+    "properties": {
+        "affinity": {
+            "type": "object"
+        },
+        "deploymentType": {
+            "type": "string",
+            "enum": ["deployment", "rollout"]
+        },
+        "extraVolumeMounts": {
+            "type": "array"
+        },
+        "extraVolumes": {
+            "type": "array"
+        },
+        "fullnameOverride": {
+            "type": "string"
+        },
+        "image": {
+            "type": "object",
+            "properties": {
+                "pullPolicy": {
+                    "type": "string"
+                },
+                "registry": {
+                    "type": "string"
+                },
+                "repository": {
+                    "type": "string"
+                },
+                "tag": {
+                    "type": "string"
+                }
+            }
+        },
+        "imagePullSecrets": {
+            "type": "array"
+        },
+        "ingress": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "className": {
+                    "type": "string"
+                },
+                "enabled": {
+                    "type": "boolean"
+                },
+                "hosts": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "host": {
+                                "type": "string"
+                            },
+                            "paths": {
+                                "type": "array",
+                                "items": {
+                                    "type": "object",
+                                    "properties": {
+                                        "path": {
+                                            "type": "string"
+                                        },
+                                        "pathType": {
+                                            "type": "string"
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                "tls": {
+                    "type": "array"
+                }
+            }
+        },
+        "krakend": {
+            "type": "object",
+            "properties": {
+                "allInOneImage": {
+                    "type": "boolean"
+                },
+                "config": {
+                    "type": "string"
+                },
+                "env": {
+                    "type": "array"
+                },
+                "extraConfig": {
+                    "type": "object"
+                },
+                "partials": {
+                    "type": "object"
+                },
+                "settings": {
+                    "type": "object"
+                },
+                "templates": {
+                    "type": "object"
+                }
+            }
+        },
+        "nameOverride": {
+            "type": "string"
+        },
+        "nodeSelector": {
+            "type": "object"
+        },
+        "podAnnotations": {
+            "type": "object"
+        },
+        "podSecurityContext": {
+            "type": "object"
+        },
+        "replicaCount": {
+            "type": "integer"
+        },
+        "resources": {
+            "type": "object"
+        },
+        "rolloutStrategy": {
+            "type": "object"
+        },
+        "securityContext": {
+            "type": "object"
+        },
+        "service": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "port": {
+                    "type": "integer"
+                },
+                "targetPort": {
+                    "type": "integer"
+                },
+                "type": {
+                    "type": "string"
+                }
+            }
+        },
+        "serviceAccount": {
+            "type": "object",
+            "properties": {
+                "annotations": {
+                    "type": "object"
+                },
+                "create": {
+                    "type": "boolean"
+                },
+                "name": {
+                    "type": "string"
+                }
+            }
+        },
+        "tolerations": {
+            "type": "array"
+        }
+    }
+}


### PR DESCRIPTION
This ensures that we get extra validation of the values when installing
the chart and gives us better CI coverage.

This also addresses a warning generated by helm lint.

Thanks @andy-v-h for suggesting this!