### PR TITLE
release: Tag before doing the release commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,13 +2,13 @@
 release: ## Issues a release
 	@test -n "$(TAG)" || (echo "The TAG variable must be set" && exit 1)
 	@echo "Releasing v$(TAG)"
+	git tag -m "Release v$(TAG)" "v$(TAG)"
 	git checkout -b "release-$(TAG)"
 	sed -i "s%version: .*%version: $(TAG)%" Chart.yaml
 	helm-docs
 	git add README.md
 	git add Chart.yaml
 	git commit -m "Release v$(TAG)"
-	git tag -m "Release v$(TAG)" "v$(TAG)"
 	git push origin "release-$(TAG)"
 	git push origin "v$(TAG)"
 


### PR DESCRIPTION
This helps us have the release tags in commited branches and thus makes
our auto-release generation actually output relevant release notes. With
the previous workflow, we'd have the tag in a commit HEAD outside of
`main`'s tree.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
