### PR TITLE
Replace `rolloutStrategy` with `strategy`

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,6 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | podSecurityContext | object | `{}` | The securityContext to use for the krakend pod |
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources | object | `{}` | The resources to use for the krakend pod |
-| rolloutStrategy | object | `{"canary":{"maxSurge":"25%","maxUnavailable":0,"steps":[{"setWeight":10},{"pause":{"duration":"1m"}},{"setWeight":30},{"pause":{"duration":"1m"}},{"setWeight":50},{"pause":{"duration":"1m"}}]}}` | The Argo Rollouts strategy to use for the krakend service For more information, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/ Note that the `deploymentType` must be set to `rollout` for this to take effect. |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | The securityContext to use for the krakend container |
 | service | object | `{"annotations":{},"port":80,"targetPort":8080,"type":"ClusterIP"}` | The service settings to use for the krakend service |
 | service.annotations | object | `{}` | The annotations to use for the service |
@@ -72,6 +71,7 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | serviceAccount.annotations | object | `{}` | The annotations to use for the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| strategy | object | `{}` | The strategy for the krakend deployment. This can either be a `deployment` or a `rollout` strategy. For more information on the Argo Rollout strategy, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/ |
 | tolerations | object | `[]` | The tolerations to use for the krakend pod |
 
 ## Development

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -15,7 +15,7 @@ spec:
     matchLabels:
       {{- include "krakend.selectorLabels" . | nindent 6 }}
   {{- if eq .Values.deploymentType "rollout" }}
-  {{- with .Values.rolloutStrategy }}
+  {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
   {{- end }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -124,7 +124,7 @@
         "resources": {
             "type": "object"
         },
-        "rolloutStrategy": {
+        "strategy": {
             "type": "object"
         },
         "securityContext": {

--- a/values.yaml
+++ b/values.yaml
@@ -15,23 +15,10 @@ image:
 # Valid values are `deployment` and `rollout`
 deploymentType: deployment
 
-# -- (object) The Argo Rollouts strategy to use for the krakend service
-# For more information, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/
-# Note that the `deploymentType` must be set to `rollout` for this to take effect.
-rolloutStrategy:
-  canary:
-    maxSurge: "25%"
-    maxUnavailable: 0
-    steps:
-    - setWeight: 10
-    - pause:
-        duration: 1m
-    - setWeight: 30
-    - pause:
-        duration: 1m
-    - setWeight: 50
-    - pause:
-        duration: 1m
+# -- (object) The strategy for the krakend deployment. This can either be
+# a `deployment` or a `rollout` strategy.
+# For more information on the Argo Rollout strategy, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/
+strategy: {}
 
 krakend:
   # -- (bool) Whether the given krakend image to be used contains everything needed


### PR DESCRIPTION
Both Argo Rollouts and kube Deployments have the `strategy` key, so
let's use that instead as opposed to relying solely on the argo rollouts
key.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
