### PR TITLE
Roll back change to push tag before commit

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 release: ## Issues a release
 	@test -n "$(TAG)" || (echo "The TAG variable must be set" && exit 1)
 	@echo "Releasing v$(TAG)"
-	git tag -m "Release v$(TAG)" "v$(TAG)"
 	git checkout -b "release-$(TAG)"
 	sed -i "s%version: .*%version: $(TAG)%" Chart.yaml
 	helm-docs
@@ -10,5 +9,6 @@ release: ## Issues a release
 	git add Chart.yaml
 	git commit -m "Release v$(TAG)"
 	git push origin "release-$(TAG)"
+	git tag -m "Release v$(TAG)" "v$(TAG)"
 	git push origin "v$(TAG)"
 


### PR DESCRIPTION
The helm release job needs the documentation in order to work
appropiately. Thus, we need to switch back to the previous behavior.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
