### PR TITLE
Add optional serviceMonitor to helm chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,13 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | serviceAccount.annotations | object | `{}` | The annotations to use for the service account |
 | serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
 | serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| serviceMonitor | object | `{"annotations":{},"enabled":false,"interval":"10s","labels":{},"scrapeTimeout":"10s","targetPort":9091}` | The serviceMonitor configures a ServiceMonitor for your application |
+| serviceMonitor.annotations | object | `{}` | Annotations to add to ServiceMonitor |
+| serviceMonitor.enabled | bool | `false` | Set to true to create a default ServiceMonitor for your application |
+| serviceMonitor.interval | string | `"10s"` | Interval for scrape metrics. |
+| serviceMonitor.labels | object | `{}` | Labels to add to ServiceMonitor |
+| serviceMonitor.scrapeTimeout | string | `"10s"` | time out interval when scraping metrics |
+| serviceMonitor.targetPort | int | `9091` | prometheus metrics port exposed by krakend |
 | strategy | object | `{}` | The strategy for the krakend deployment. This can either be a `deployment` or a `rollout` strategy. For more information on the Argo Rollout strategy, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/ |
 | tolerations | object | `[]` | The tolerations to use for the krakend pod |
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -75,6 +75,11 @@ spec:
             - name: http
               containerPort: {{ .Values.service.targetPort }}
               protocol: TCP
+          {{- if .Values.serviceMonitor.enabled }}
+            - name: metrics
+              containerPort: {{ .Values.serviceMonitor.targetPort }}
+              protocol: TCP
+          {{- end }}
           {{- with .Values.livenessProbe }}
           livenessProbe: {{ toYaml . | nindent 12 }}
           {{- end }}

--- a/templates/service-monitor.yaml
+++ b/templates/service-monitor.yaml
@@ -1,0 +1,19 @@
+{{ if .Values.serviceMonitor.enabled -}}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ include "krakend.fullname" . }}
+  labels: {{- include "krakend.labels" . | nindent 4 }}
+  {{- if .Values.serviceMonitor.annotations }}
+  annotations:
+    {{- range $key, $value := .Values.serviceMonitor.annotations }}
+    {{ $key }}: {{ tpl $value $ | quote }}
+    {{- end }}
+  {{- end }}
+spec:
+  selector:
+    matchLabels: {{- include "krakend.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: {{ .Values.serviceMonitor.targetPort }}
+{{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -205,3 +205,18 @@ readinessProbe:
   httpGet:
     path: /__health
     port: http
+
+# -- (object) The serviceMonitor configures a ServiceMonitor for your application
+serviceMonitor:
+  # -- (bool) Set to true to create a default ServiceMonitor for your application
+  enabled: false
+  # -- Labels to add to ServiceMonitor
+  labels: {}
+  # -- Annotations to add to ServiceMonitor
+  annotations: {}
+  # -- Interval for scrape metrics.
+  interval: 10s
+  # -- time out interval when scraping metrics
+  scrapeTimeout: 10s
+  # -- prometheus metrics port exposed by krakend
+  targetPort: 9091


### PR DESCRIPTION
This adds an optional serviceMonitor to the `krakend` deployment.  Note: `krakend` will need to expose prometheus in the config as well - something like:

```json
"telemetry/opencensus": {
    "sample_rate": 100,
    "reporting_period": 1,
    "enabled_layers": {
        "backend": true,
        "router": true
    },
  "exporters": {
    "prometheus": {
        "port": 9091,
        "tag_host": true,
        "tag_path": true,
        "tag_method": true,
        "tag_statuscode": true
    }
  }
}
```