### PR TITLE
Don't annotate checksums if we're using the all-in-one image

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -23,7 +23,7 @@ spec:
   template:
     metadata:
       annotations:
-        {{- if .Values.krakend.allInOneImage }}
+        {{- if not .Values.krakend.allInOneImage }}
         checksum/cm-config: {{ include (print $.Template.BasePath "/cm-config.yaml") . | sha256sum }}
         checksum/cm-partials: {{ include (print $.Template.BasePath "/cm-partials.yaml") . | sha256sum }}
         checksum/cm-settings: {{ include (print $.Template.BasePath "/cm-settings.yaml") . | sha256sum }}


### PR DESCRIPTION
We only need those checksums if we're using the ConfigMap approach
that's used for testing. If we're using the all-in-one image, these
checksum annotations are not needed.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
