### PR TITLE
Update Chart appVersion on release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,7 @@ release: ## Issues a release
 	@echo "Releasing v$(TAG)"
 	git checkout -b "release-$(TAG)"
 	sed -i "s%version: .*%version: $(TAG)%" Chart.yaml
+	sed -i "s%appVersion: .*%appVersion: $(shell yq '.image.tag' values.yaml)%" Chart.yaml
 	helm-docs
 	git add README.md
 	git add Chart.yaml


### PR DESCRIPTION
The app version should reflect the version of the supported krakend
release, this PR updates the `release` Makefile target to do so.

This now requires the `yq` command to be installed on the release
manager's machine.

Signed-off-by: Juan Antonio Osorio <juan.osoriorobles@eu.equinix.com>
