### PR TITLE
feat: add extra service port to reach the metrics port

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,9 +86,13 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | replicaCount | int | `1` | Number of replicas to deploy |
 | resources | object | `{}` | The resources to use for the krakend pod |
 | securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"add":["NET_BIND_SERVICE"],"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsNonRoot":true,"runAsUser":1000}` | The securityContext to use for the krakend container |
-| service | object | `{"annotations":{},"externalTrafficPolicy":"","port":80,"targetPort":8080,"type":"ClusterIP"}` | The service settings to use for the krakend service |
+| service | object | `{"annotations":{},"externalTrafficPolicy":"","metrics":{"enabled":false,"port":9100,"targetPort":9100},"port":80,"targetPort":8080,"type":"ClusterIP"}` | The service settings to use for the krakend service |
 | service.annotations | object | `{}` | The annotations to use for the service |
 | service.externalTrafficPolicy | string | `""` | The External Traffic Policy of the service |
+| service.metrics | object | `{"enabled":false,"port":9100,"targetPort":9100}` | The service settings to reach the metrics port |
+| service.metrics.enabled | bool | `false` | Specifies whether the metrics port is reachable |
+| service.metrics.port | int | `9100` | The port to use for the metrics service |
+| service.metrics.targetPort | int | `9100` | The target port to use for the metrics service |
 | service.port | int | `80` | The port to use for the service |
 | service.targetPort | int | `8080` | The target port to use for the service |
 | service.type | string | `"ClusterIP"` | The type of service to use |

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -20,5 +20,11 @@ spec:
       targetPort: {{ .Values.service.targetPort }}
       protocol: TCP
       name: http
+    {{- if .Values.service.metrics.enabled }}
+    - port: {{ .Values.service.metrics.port }}
+      targetPort: {{ .Values.service.metrics.targetPort }}
+      protocol: TCP
+      name: metric
+    {{- end }}
   selector:
     {{- include "krakend.selectorLabels" . | nindent 4 }}

--- a/values.yaml
+++ b/values.yaml
@@ -158,6 +158,14 @@ service:
   targetPort: 8080
   # -- (object) The annotations to use for the service
   annotations: {}
+  # -- (object) The service settings to reach the metrics port
+  metrics:
+    # -- (bool) Specifies whether the metrics port is reachable
+    enabled: false
+    # -- (int) The port to use for the metrics service
+    port: 9100
+    # -- (int) The target port to use for the metrics service
+    targetPort: 9100
 
 # -- (object) The ingress settings to use for the krakend ingress
 ingress:


### PR DESCRIPTION
Hey folks 👋 ,

First of all, thanks a lot for your work on that repos 🎉 it is really helpful and useful🙏 

The goal of this PR is to reach the metrics port from the kubernetes service object in order to scrape it from prometheus.
I know there is the serviceMonitor object which is already present but some of us don't have an implementation of the monitoring stack with the prometheus-operator

Don't hesitate to reach for any questions 😉 

Cheers ☀️ 