### PR TITLE
fix: hpa manages Deployment.replicas when configured

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -10,7 +10,9 @@ metadata:
   labels:
     {{- include "krakend.labels" . | nindent 4 }}
 spec:
+  {{- if not .Values.autoscaling.enabled }}
   replicas: {{ .Values.replicaCount }}
+  {{- end }}
   selector:
     matchLabels:
       {{- include "krakend.selectorLabels" . | nindent 6 }}


### PR DESCRIPTION
As documented:

If a HorizontalPodAutoscaler (or any similar API for horizontal scaling) is managing scaling for a Deployment, don't set .spec.replicas.

https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#replicas