### PR TITLE
fix(k8s): Deployment.strategy is independent of deploymentType

### DIFF
--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -16,11 +16,9 @@ spec:
   selector:
     matchLabels:
       {{- include "krakend.selectorLabels" . | nindent 6 }}
-  {{- if eq .Values.deploymentType "rollout" }}
   {{- with .Values.strategy }}
   strategy:
     {{- toYaml . | nindent 4 }}
-  {{- end }}
   {{- end }}
   template:
     metadata:

--- a/values.yaml
+++ b/values.yaml
@@ -19,6 +19,9 @@ deploymentType: deployment
 # a `deployment` or a `rollout` strategy.
 # For more information on the Argo Rollout strategy, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/
 strategy: {}
+#  rollingUpdate:
+#    maxSurge: 25%
+#    maxUnavailable: 10%
 
 krakend:
   # -- (bool) Whether the given krakend image to be used contains everything needed


### PR DESCRIPTION
When unset, k8s defaults are the following:

rollingUpdate:
  maxSurge: 25%
  maxUnavailable: 25%

Currently, the same values are set when deploymentType is "deployment".

After merging this patch, defaults will be the same, but we'll be able to override them independently of deploymentType.