### PR TITLE
Add Conditional Logic for deploymentAnnotations in Helm Chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 |-----|------|---------|-------------|
 | affinity | object | `{}` | The affinity to use for the krakend pod |
 | autoscaling | object | `{"annotations":{},"behavior":{},"enabled":false,"maxReplicas":3,"minReplicas":1,"targetCPUUtilizationPercentage":50,"targetMemoryUtilizationPercentage":50}` | Configures HorizontalPodAutoscaler for your Deployment |
+| deploymentAnnotations | object | `{}` | The annotations to use for the krakend Deployment |
 | deploymentType | string | `"deployment"` | The deployment type to use for the krakend service Valid values are `deployment` and `rollout` |
 | extraVolumeMounts | array | `[]` | extraVolumeMounts allows you to mount extra volumes to the krakend pod |
 | extraVolumes | array | `[]` | extraVolumes allows you to mount extra volumes to the krakend pod |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,7 +9,7 @@ metadata:
   name: {{ include "krakend.fullname" . }}
   labels:
     {{- include "krakend.labels" . | nindent 4 }}
-  {{- if .Values.deploymentAnnotations }}
+  {{- with .Values.deploymentAnnotations }}
   annotations:
     {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
   {{- end }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -11,7 +11,7 @@ metadata:
     {{- include "krakend.labels" . | nindent 4 }}
   {{- with .Values.deploymentAnnotations }}
   annotations:
-    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+    {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
   {{- if eq .Values.autoscaling.enabled .Values.keda.enabled }}

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -9,6 +9,10 @@ metadata:
   name: {{ include "krakend.fullname" . }}
   labels:
     {{- include "krakend.labels" . | nindent 4 }}
+  {{- if .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml .Values.deploymentAnnotations | nindent 4 }}
+  {{- end }}
 spec:
   {{- if eq .Values.autoscaling.enabled .Values.keda.enabled }}
   replicas: {{ .Values.replicaCount }}

--- a/values.yaml
+++ b/values.yaml
@@ -140,6 +140,9 @@ serviceAccount:
 # -- (object) The annotations to use for the krakend pod
 podAnnotations: {}
 
+# -- (object) The annotations to use for the krakend deployment
+deploymentAnnotations: {}
+
 # -- (object) Labels to use for the krakend pod
 podLabels: {}
 


### PR DESCRIPTION
## Changes Description

This pull request introduces changes to the Helm template to implement conditional logic for `deploymentAnnotations`. The update ensures that the `annotations:` block is only included in the Kubernetes Deployment manifest if `deploymentAnnotations` are defined in the `values.yaml` file.

## Motivation

The motivation behind this change is to keep the Deployment manifest clean and free from empty or unnecessary annotations when no `deploymentAnnotations` are specified, thereby preventing potential deployment issues and maintaining clarity in the manifest files.

## Implementation Details

- An `if` statement checks for the presence of `deploymentAnnotations` in the `values.yaml`.
- If `deploymentAnnotations` exist, the annotations block is added to the Deployment manifest.
- If there are no `deploymentAnnotations`, the annotations block is completely omitted, ensuring that only relevant metadata is included in the deployed resources.

This approach helps in managing the Deployment's metadata more dynamically based on the configuration provided and avoids cluttering the Kubernetes manifest with empty or irrelevant annotations.

## Additional Notes

Please review the changes to ensure that the conditional logic aligns with our deployment standards and let me know if any adjustments are required.
