### PR TITLE
Don't explicitly set app version and version in release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,8 +22,6 @@ jobs:
           charts_url: 'https://helm.equinixmetal.com'
           repository: 'charts'
           branch: gh-pages
-          app_version: ${{  github.ref_name }}
-          chart_version: ${{  github.ref_name }}
 
   gh-release:
     name: Create GitHub Release


### PR DESCRIPTION
Let's get these from the chart file itself as it already has the correct
info.

Signed-off-by: Juan Antonio Osorio <ozz@stacklok.com>
