### PR TITLE
Added integrated designer instance. Updated values, schema and readme.

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | krakend.settingsDirSource | string, optional | `""` | an external file relative path, will contain the setting configuration files of the krakend service. |
 | krakend.templates | object | `{}` | While default configuration does not take into use templates; you may want to add your own templates here. Note that you'd need to set a custom configuration file to use them. |
 | krakend.templatesDirSource | string, optional | `""` | an external file relative path, will contain the template configuration files of the krakend service. |
+| krakend.designer.enabled | bool | `false` | Specifies whether an designer should be created |
+| krakend.designer.port | int | `8088` | The port to use for the designer service |
+| krakend.designer.targetPort | int | `80` | The target port to use for the designer service |
+| krakend.designed.repository | string | `"krakend/designer"` | The image repository to use |
+| krakend.designed.tag | string | `"2.4"` | The image tag to use |
+| krakend.designer.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use |
+| krakend.designer.livenessProbe | object | `{"httpGet":{"path":"/","port":"designer"}}` | The livenessProbe to use for the designer |
+| krakend.designer.readinessProbe | object | `{"httpGet":{"path":"/","port":"designer"}}` | The readinessProbe to use for the designer |
+| krakend.designer.resources | object | `{}` | The resources to use for the designer |
 | lifecycle | object | `{}` | Krakend container lifecycle hooks (PostStart, PreStop) |
 | livenessProbe | object | `{"httpGet":{"path":"/__health","port":"http"}}` | The livenessProbe to use for the krakend pod |
 | nameOverride | string | `""` |  |

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -51,6 +51,23 @@ spec:
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       containers:
+        {{- if .Values.krakend.designer.enabled }}
+        - name: designer
+          image: "{{ .Values.image.registry }}/{{ .Values.krakend.designer.repository }}:{{ .Values.krakend.designer.tag}}"
+          imagePullPolicy: {{ .Values.krakend.designer.pullPolicy }}
+          ports:
+            - name: designer
+              containerPort: {{ .Values.krakend.designer.targetPort }}
+              protocol: TCP
+          {{- with .Values.krakend.designer.livenessProbe }}
+          livenessProbe: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.krakend.designer.readinessProbe }}
+          readinessProbe: {{ toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.krakend.designer.resources | nindent 12 }}
+        {{- end }}
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}

--- a/templates/service.yaml
+++ b/templates/service.yaml
@@ -27,5 +27,11 @@ spec:
       protocol: TCP
       name: metric
     {{- end }}
+    {{- if .Values.krakend.designer.enabled }}
+    - port: {{ .Values.krakend.designer.port }}
+      targetPort: {{ .Values.krakend.designer.targetPort }}
+      protocol: TCP
+      name: designer
+    {{- end }}
   selector:
     {{- include "krakend.selectorLabels" . | nindent 4 }}

--- a/values.schema.json
+++ b/values.schema.json
@@ -110,6 +110,38 @@
                 },
                 "templates": {
                     "type": "object"
+                },
+                "designer": {
+                    "type": "object",
+                    "properties": {
+                        "enabled": {
+                            "type": "boolean"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "targetPort": {
+                            "type": "integer"
+                        },
+                        "port": {
+                            "type": "integer"
+                        },
+                        "repository": {
+                            "type": "string"
+                        },
+                        "tag": {
+                            "type": "string"
+                        },
+                        "livenessProbe": {
+                            "type": "object"
+                        },
+                        "readinessProbe": {
+                            "type": "object"
+                        },
+                        "resources": {
+                            "type": "object"
+                        }
+                    }
                 }
             }
         },

--- a/values.yaml
+++ b/values.yaml
@@ -125,6 +125,32 @@ krakend:
       logger_skip_paths:
         - "/__health"
 
+  designer:
+    # -- (bool) Specifies whether an designer should be created
+    enabled: true
+    # -- (int) The port to use for the designer service
+    port: 8088
+    # -- (int) The target port to use for the designer service
+    targetPort: 80
+    # -- The image repository to use
+    repository: krakend/designer
+    # -- The image tag to use
+    tag: "2.4"
+    # -- The image pull policy to use
+    pullPolicy: IfNotPresent
+    # -- (object) The livenessProbe to use for the designer
+    livenessProbe:
+      httpGet:
+        path: /
+        port: designer
+    # -- (object) The readinessProbe to use for the designer
+    readinessProbe:
+      httpGet:
+        path: /
+        port: designer
+    # -- (object) The resources to use for the designer
+    resources: {}
+
 # -- (list) List of secrets containing the credentials to use for the image
 imagePullSecrets: []
 nameOverride: ""


### PR DESCRIPTION
Add local designer instance according to https://github.com/krakend/krakendesigner
Integrated as second container in pod + service port. 
Configuration pretty simple. Disabled by default.