### PR TITLE
fix: observe pod as not-ready for some time before it is restarted

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -251,6 +251,7 @@ initContainers: {}
 
 # -- (object) The livenessProbe to use for the krakend pod
 livenessProbe:
+  failureThreshold: 6
   httpGet:
     path: /__health
     port: http


### PR DESCRIPTION
From https://learnk8s.io/production-best-practices:

_Liveness probes values aren't the same as the Readiness_

When Liveness and Readiness probes are pointing to the same endpoint, the effects of the probes are combined.

When the app signals that it's not ready or live, the kubelet detaches the container from the Service and delete it at the same time.

You might notice dropping connections because the container does not have enough time to drain the current connections or process the incoming ones.

You can dig deeper in the following [article that discussed graceful shutdown](https://freecontent.manning.com/handling-client-requests-properly-with-kubernetes/).