### PR TITLE
Add option to hash external config maps

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | deploymentType | string | `"deployment"` | The deployment type to use for the krakend service Valid values are `deployment` and `rollout` |
 | extraVolumeMounts | array | `[]` | extraVolumeMounts allows you to mount extra volumes to the krakend pod |
 | extraVolumes | array | `[]` | extraVolumes allows you to mount extra volumes to the krakend pod |
+| externalConfigMapsToHash | array | `[]` | List of external ConfigMap names to hash for rollout triggers. If you mount external ConfigMaps via extraVolumes, list their names here to ensure the deployment rolls when they change. |
 | fullnameOverride | string | `""` |  |
 | image.pullPolicy | string | `"IfNotPresent"` | The image pull policy to use |
 | image.registry | string | `"docker.io"` | The image registry to use |
@@ -129,6 +130,21 @@ please refer to [the official krakend documentation](https://www.krakend.io/docs
 | strategy | object | `{}` | The strategy for the krakend deployment. This can either be a `deployment` or a `rollout` strategy. For more information on the Argo Rollout strategy, see https://argo-rollouts.readthedocs.io/en/stable/features/specification/ |
 | tolerations | object | `[]` | The tolerations to use for the krakend pod |
 | topologySpreadConstraints | array | `[]` | The topologySpreadConstraints to use for the krakend pod |
+
+## Hashing External ConfigMaps for Rollouts
+
+If you mount external ConfigMaps using `extraVolumes`, you can ensure your deployment rolls when those ConfigMaps change by specifying their names in `externalConfigMapsToHash`:
+
+```yaml
+extraVolumes:
+  - name: my-external-configmap
+    configMap:
+      name: my-external-configmap
+externalConfigMapsToHash:
+  - name: my-external-configmap
+```
+
+This will add a checksum annotation for each listed ConfigMap, so any change to the ConfigMap will trigger a new rollout.
 
 ## Development
 

--- a/templates/deployment.yaml
+++ b/templates/deployment.yaml
@@ -34,6 +34,11 @@ spec:
         checksum/cm-settings: {{ include (print $.Template.BasePath "/cm-settings.yaml") . | sha256sum }}
         checksum/cm-templates: {{ include (print $.Template.BasePath "/cm-templates.yaml") . | sha256sum }}
         {{- end }}
+        {{- with .Values.externalConfigMapsToHash }}
+        {{- range . }}
+        checksum/external-cm-{{ .name }}: {{ (lookup "v1" "ConfigMap" $.Release.Namespace .name).data | toYaml | sha256sum }}
+        {{- end }}
+        {{- end }}
         {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
         {{- end }}

--- a/values.yaml
+++ b/values.yaml
@@ -230,6 +230,13 @@ extraVolumeMounts: []
 # -- (array) extraVolumes allows you to mount extra volumes to the krakend pod
 extraVolumes: []
 
+# -- (array) List of external ConfigMap names to hash for rollout triggers.
+# If you mount external ConfigMaps via extraVolumes, list their names here to ensure the deployment rolls when they change.
+# Example:
+# externalConfigMapsToHash:
+#   - name: my-external-configmap
+externalConfigMapsToHash: []
+
 ## Add your own init container (example installation of plugins)
 ## Ref: https://kubernetes.io/docs/concepts/workloads/pods/init-containers/
 initContainers: {}


### PR DESCRIPTION
Adds a `externalConfigMapsToHash` option to add a checksum annotation for each listed ConfigMap, so any change to the ConfigMap will trigger a new rollout.

If you have suggestions for a better name I'm happy to update the PR.

To me this is helpful, since I set `allInOneImage` to `true` and then mount my config not from values.yaml but custom config maps. This works really nice, except now my pods are not restarted when the configuration changes.